### PR TITLE
Changed "Join Our Discord" button to "Join Us" on the home page

### DIFF
--- a/src/components/sections/Hero.js
+++ b/src/components/sections/Hero.js
@@ -70,7 +70,7 @@ const Hero = ({
               <div className="reveal-from-bottom" data-reveal-delay="600">
                 <ButtonGroup>
                   <Button tag="a" target="_blank" color="primary" wideMobile href="https://discord.com/invite/9VpWAA3EZU">
-                    JOIN OUR DISCORD
+                    Join Us
                     </Button>
                   <Button tag="a" color="dark" wideMobile href="https://github.com/javaScriptKampala">
                     View on Github


### PR DESCRIPTION
Fixes #29 

Changed the text as required
![image](https://user-images.githubusercontent.com/75690289/146909143-7572d21c-489e-4b73-bc1a-615435fc20ff.png)
